### PR TITLE
remove "#![deny(warnings)]"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 //! assert_eq!(rx.wait().unwrap(), "foo");
 //! # }
 //! ```
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 extern crate futures;


### PR DESCRIPTION
This is bad idea to have this in library because anytime if some dependency deprecates something, crate fails to build. Right option is to set this flag from CI.