### PR TITLE
convert to futures 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/seanmonstar/relay"
 documentation = "https://docs.rs/relay"
 
 [dependencies]
-futures = "0.1"
+futures = "0.2.0-alpha"


### PR DESCRIPTION
I'm currently rebasing my futures 0.2 branch on top of `hyper`'s master branch, so I needed a version of `relay` that works with the alpha release of futures 0.2.

EDIT: Actually it looks like I won't be needing this, but of course feel free to review and merge it anyway ;)